### PR TITLE
Check license compliance

### DIFF
--- a/check-license-compliance.sh
+++ b/check-license-compliance.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+# See https://xtranet.sonarsource.com/display/DEV/Open+Source+Licenses
+
+mvn org.codehaus.mojo:license-maven-plugin:add-third-party

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>44</version>
+    <version>45</version>
   </parent>
 
   <groupId>org.sonarsource.auth.bitbucket</groupId>

--- a/travis.sh
+++ b/travis.sh
@@ -13,3 +13,5 @@ source ~/.local/bin/installMaven35
 
 export DEPLOY_PULL_REQUEST=true
 regular_mvn_build_deploy_analyze
+
+./check-license-compliance.sh


### PR DESCRIPTION
Check license compliance on Travis
    
Upgrading to parent 45 allows to improve the verification of
license compliance of third-party dependencies.
    
The new script check-license-compliance.sh fails if a dependency
has a license that is not compatible with SonarSource policy.
    
See https://xtranet.sonarsource.com/display/DEV/Open+Source+Licenses
for more details.
